### PR TITLE
Editing Mode and Loading Refactor

### DIFF
--- a/src/app/constants.js
+++ b/src/app/constants.js
@@ -13,7 +13,6 @@
       INSERT_MEDIA: 'insert_media'
     },
     FRAME_ACTIONS: {
-      LOAD_EDITOR: 'load_editor',
       GET_MEDIAS: 'get_medias',
       MEDIAS_DATA: 'medias_data',
       CANCEL_EDITOR: 'cancel_editor',

--- a/src/app/main.js
+++ b/src/app/main.js
@@ -1,33 +1,35 @@
 (function(global) {
   'use strict';
 
-  $('body').prepend( $('<toolbar></toolbar>') );
-  $('body').append( $('<media-library></media-library>') );
-  $('head').append( $('<link rel="stylesheet" type="text/css" />').attr('href', 'http://fonts.googleapis.com/css?family=Roboto:400,500,700,300,100') );
-  $('head').append( $('<link rel="stylesheet" type="text/css" />').attr('href', 'https://fonts.googleapis.com/icon?family=Material+Icons') );
-  $('head').append( $('<link rel="stylesheet" type="text/css" />').attr('href', config.CONTENT_SNIPPETS_EDIT_CSS_URL) );
-  $.getScript('https://cdn.ckeditor.com/4.5.6/standard/ckeditor.js', function() {
-    global.CKEDITOR.config.autoParagraph = false;
-    global.CKEDITOR.config.allowedContent = true;
-    global.CKEDITOR.plugins.addExternal( 'media-selector', global.config.CKEDITOR_PLUGINS_URL + 'media-selector/', 'plugin.js' );
-    global.CKEDITOR.plugins.addExternal( 'sourcedialog', global.config.CKEDITOR_PLUGINS_URL + 'sourcedialog/', 'plugin.js' );
-    global.CKEDITOR.plugins.addExternal( 'codemirror', global.config.CKEDITOR_PLUGINS_URL + 'codemirror/', 'plugin.js' );
-    global.CKEDITOR.config.extraPlugins = 'media-selector,sourcedialog';
-    global.CKEDITOR.config.removePlugins = 'image,sourcearea';
+  $(function() {
+    $('body').prepend( $('<toolbar></toolbar>') );
+    $('body').append( $('<media-library></media-library>') );
+    $('head').append( $('<link rel="stylesheet" type="text/css" />').attr('href', 'http://fonts.googleapis.com/css?family=Roboto:400,500,700,300,100') );
+    $('head').append( $('<link rel="stylesheet" type="text/css" />').attr('href', 'https://fonts.googleapis.com/icon?family=Material+Icons') );
+    $('head').append( $('<link rel="stylesheet" type="text/css" />').attr('href', config.CONTENT_SNIPPETS_EDIT_CSS_URL) );
+    $.getScript('https://cdn.ckeditor.com/4.5.8/standard/ckeditor.js', function() {
+      global.CKEDITOR.config.autoParagraph = false;
+      global.CKEDITOR.config.allowedContent = true;
+      global.CKEDITOR.plugins.addExternal( 'media-selector', global.config.CKEDITOR_PLUGINS_URL + 'media-selector/', 'plugin.js' );
+      global.CKEDITOR.plugins.addExternal( 'sourcedialog', global.config.CKEDITOR_PLUGINS_URL + 'sourcedialog/', 'plugin.js' );
+      global.CKEDITOR.plugins.addExternal( 'codemirror', global.config.CKEDITOR_PLUGINS_URL + 'codemirror/', 'plugin.js' );
+      global.CKEDITOR.config.extraPlugins = 'media-selector,sourcedialog';
+      global.CKEDITOR.config.removePlugins = 'image,sourcearea';
 
-    var stores = {
-      WebpageStore: new WebpageStore(),
-      MediasStore: new MediasStore()
-    };
+      var stores = {
+        WebpageStore: new WebpageStore(),
+        MediasStore: new MediasStore()
+      };
 
-    for (var k in stores) {
-      RiotControl.addStore(stores[k]);
-    }
+      for (var k in stores) {
+        RiotControl.addStore(stores[k]);
+      }
 
-    global.stores = stores;
+      global.stores = stores;
 
-    riot.mount('snippet');
-    riot.mount('media-library');
-    riot.mount('toolbar');
+      riot.mount('snippet');
+      riot.mount('media-library');
+      riot.mount('toolbar');
+    });
   });
 }(this));

--- a/src/app/stores/WebpageStore.js
+++ b/src/app/stores/WebpageStore.js
@@ -18,7 +18,7 @@
 
   WebpageStore.prototype._fetch = function() {
     return new Promise(function(resolve, reject) {
-      var url = window.location.href;
+      var url = location.protocol + '//' + location.host + location.pathname;
       this._api
         .get(config.API_ROUTES.WEBPAGES_FEED + '?url=' + encodeURIComponent(url))
         .then(function(webpage) {
@@ -38,7 +38,7 @@
       foundSnippetIndex = _.findIndex(this.webpage.snippets, function(obj) {
         return obj.document.name === snippet.name;
       });
-    
+
     if (foundSnippetIndex >= 0) {
       this.webpage.snippets[foundSnippetIndex].document.body = snippet.body;
     }


### PR DESCRIPTION
- Pull snippets from correct URL when editing mode is enabled
- Assume `content-snippets-edit` is being loaded as a normal external script, rather than using jQuery's dynamic `getScript` method
